### PR TITLE
[FEAT] 스플래시 뷰 UI 구현 (#8)

### DIFF
--- a/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS.xcodeproj/project.pbxproj
+++ b/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		CA2CBE4E2BF90E7A00049F8F /* SuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE4D2BF90E7A00049F8F /* SuccessViewController.swift */; };
 		CA2CBE502BF90E9600049F8F /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE4F2BF90E9600049F8F /* AlertViewController.swift */; };
 		CA2CBE522BF90EB400049F8F /* RegisterToDoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE512BF90EB400049F8F /* RegisterToDoViewController.swift */; };
-		CA2CBE542BF90EC300049F8F /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE532BF90EC300049F8F /* SplashViewController.swift */; };
-		CA2CBE562BF90EDA00049F8F /* OnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE552BF90EDA00049F8F /* OnBoardingViewController.swift */; };
+		CA2CBE592BF910E800049F8F /* OnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE582BF910E800049F8F /* OnBoardingViewController.swift */; };
+		CA2CBE5C2BF915AF00049F8F /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2CBE5B2BF915AF00049F8F /* SplashViewController.swift */; };
 		D0C0C0FE2BF8ED38005A7D5C /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0C0FD2BF8ED38005A7D5C /* UITextField+.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,8 +66,8 @@
 		CA2CBE4D2BF90E7A00049F8F /* SuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessViewController.swift; sourceTree = "<group>"; };
 		CA2CBE4F2BF90E9600049F8F /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		CA2CBE512BF90EB400049F8F /* RegisterToDoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterToDoViewController.swift; sourceTree = "<group>"; };
-		CA2CBE532BF90EC300049F8F /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
-		CA2CBE552BF90EDA00049F8F /* OnBoardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingViewController.swift; sourceTree = "<group>"; };
+		CA2CBE582BF910E800049F8F /* OnBoardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingViewController.swift; sourceTree = "<group>"; };
+		CA2CBE5B2BF915AF00049F8F /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		D0C0C0FD2BF8ED38005A7D5C /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,7 +181,7 @@
 		CA2CBE452BF90DCF00049F8F /* OnBoarding */ = {
 			isa = PBXGroup;
 			children = (
-				CA2CBE552BF90EDA00049F8F /* OnBoardingViewController.swift */,
+				CA2CBE572BF9104800049F8F /* ViewControllers */,
 			);
 			path = OnBoarding;
 			sourceTree = "<group>";
@@ -189,7 +189,7 @@
 		CA2CBE462BF90DE000049F8F /* Splash */ = {
 			isa = PBXGroup;
 			children = (
-				CA2CBE532BF90EC300049F8F /* SplashViewController.swift */,
+				CA2CBE5A2BF9159B00049F8F /* ViewControllers */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
@@ -224,6 +224,22 @@
 				CA2CBE4B2BF90E6D00049F8F /* CheckToDoViewController.swift */,
 			);
 			path = CheckToDo;
+			sourceTree = "<group>";
+		};
+		CA2CBE572BF9104800049F8F /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				CA2CBE582BF910E800049F8F /* OnBoardingViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		CA2CBE5A2BF9159B00049F8F /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				CA2CBE5B2BF915AF00049F8F /* SplashViewController.swift */,
+			);
+			path = ViewControllers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -326,13 +342,13 @@
 				CA2CBE022BF8DD3A00049F8F /* AppDelegate.swift in Sources */,
 				CA2CBE312BF8E00600049F8F /* UIView+.swift in Sources */,
 				CA2CBE2B2BF8DF9C00049F8F /* UIFont+.swift in Sources */,
-				CA2CBE542BF90EC300049F8F /* SplashViewController.swift in Sources */,
 				D0C0C0FE2BF8ED38005A7D5C /* UITextField+.swift in Sources */,
-				CA2CBE562BF90EDA00049F8F /* OnBoardingViewController.swift in Sources */,
+				CA2CBE592BF910E800049F8F /* OnBoardingViewController.swift in Sources */,
 				CA2CBE292BF8DF5600049F8F /* UICollectionViewCell+.swift in Sources */,
 				CA2CBE4E2BF90E7A00049F8F /* SuccessViewController.swift in Sources */,
 				CA2CBE502BF90E9600049F8F /* AlertViewController.swift in Sources */,
 				CA2CBE042BF8DD3A00049F8F /* SceneDelegate.swift in Sources */,
+				CA2CBE5C2BF915AF00049F8F /* SplashViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/Presentation/OnBoarding/ViewControllers/OnBoardingViewController.swift
+++ b/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/Presentation/OnBoarding/ViewControllers/OnBoardingViewController.swift
@@ -1,0 +1,29 @@
+//
+//  OnBoardingViewController.swift
+//  34th-SOPKATHON-Team1-iOS
+//
+//  Created by 윤희슬 on 5/19/24.
+//
+
+import UIKit
+
+class OnBoardingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/Presentation/Splash/ViewControllers/SplashViewController.swift
+++ b/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/Presentation/Splash/ViewControllers/SplashViewController.swift
@@ -1,0 +1,75 @@
+//
+//  OnBoardingViewController.swift
+//  34th-SOPKATHON-Team1-iOS
+//
+//  Created by 윤희슬 on 5/19/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SplashViewController: UIViewController {
+    
+    // MARK: - UI Properties
+    
+    private let graphicImageView: UIImageView = UIImageView()
+    
+    
+    // MARK: - Properties
+    
+    private let screenWidth: CGFloat = UIScreen.main.bounds.width
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setHierarchy()
+        setLayout()
+        setStyle()
+        setSplash()
+    }
+    
+}
+
+
+// MARK: - Private Methods
+
+private extension SplashViewController {
+    
+    func setHierarchy() {
+        self.view.addSubview(graphicImageView)
+    }
+    
+    func setLayout() {
+        graphicImageView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(screenWidth - 32)
+            $0.centerY.equalToSuperview()
+        }
+        
+    }
+    
+    func setStyle() {
+        self.view.backgroundColor = UIColor(resource: .black000)
+        
+        graphicImageView.do {
+            $0.image = UIImage(resource: .dummy8)
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 12
+        }
+    }
+    
+    func setSplash() {
+        UIView.animate(withDuration: 2.0,
+                       animations: {
+            self.view.alpha = 0.0
+        },
+                       completion: { finish in
+            let onBoardingVC = OnBoardingViewController()
+            self.navigationController?.pushViewController(onBoardingVC, animated: false)
+        })
+    }
+}

--- a/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/SceneDelegate.swift
+++ b/34th-SOPKATHON-Team1-iOS/34th-SOPKATHON-Team1-iOS/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: ViewController())
+        let navigationController = UINavigationController(rootViewController: SplashViewController())
         self.window?.rootViewController = navigationController
         // 4.
         self.window?.makeKeyAndVisible()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- feature/#8

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
스플래시 뷰 UI 구현

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
스플래시 뷰가 2초동안 지속되다가 점점 흐려지면서 다음 뷰컨으로 전환되도록 구현했습니다

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-05-19 at 02 11 51](https://github.com/34th-SOPKATHON-iOS-TEAM1/iOS/assets/105407130/c5fed5fe-b6e2-419c-a5be-925785cf548d)|



## 📟 관련 이슈
- Resolved: #8 
